### PR TITLE
Add published ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ starts to execute. To use it, include the following ARN as a layer in your
 Lambda function:
 
 ```text
-TBD
+arn:aws:lambda:us-east-1:634166935893:layer:vault-lambda-extension:6
 ```
+
+Where region may be any of `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`,
+`ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `eu-central-1`,
+`eu-west-1`, `eu-west-2`, `eu-west-3`, `sa-east-1`, `us-east-1`, `us-east-2`,
+`us-west-1`, `us-west-2`.
 
 The extension authenticates with Vault using [AWS IAM auth][vault-aws-iam-auth],
 and writes the result as JSON to disk. It also writes a vault token to
@@ -48,7 +53,7 @@ vault write auth/aws/role/vault-lambda-role \
 Add the extension to your Lambda layers using the console or [cli][lambda-add-layer-cli]:
 
 ```text
-TBD
+arn:aws:lambda:<your-region>:634166935893:layer:vault-lambda-extension:6
 ```
 
 Configure the extension using [Lambda environment variables][lambda-env-vars]:

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -9,7 +9,7 @@ Creates the infrastructure required for running a demo of the Vault Lambda exten
 * A Lambda function which requests database credentials from the extension and then uses them to list users on the database
 
 **NB: This demo will create real infrastructure in AWS with an associated
-cost. Make sure you tear down the infrastructure once you are finished with 
+cost. Make sure you tear down the infrastructure once you are finished with
 the demo.**
 
 **NB: This is not a production-ready deployment, and is for demonstration

--- a/quick-start/terraform/lambda.tf
+++ b/quick-start/terraform/lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "function" {
   filename      = "../demo-function/demo-function.zip"
   handler       = "main"
   runtime       = "provided.al2"
-  layers        = ["arn:aws:lambda:us-east-1:634166935893:layer:vault-lambda-extension-test:4"]
+  layers        = ["arn:aws:lambda:${var.aws_region}:634166935893:layer:vault-lambda-extension:6"]
 
   environment {
     variables = {


### PR DESCRIPTION
Also make clear that users will have to set the region in the ARN to match their infrastructure.

Edit: I've now tested it with a non-default region too:

```text
$ aws lambda invoke --function-name tomhjp-function /dev/null \
>     --cli-binary-format raw-in-base64-out \
>     --log-type Tail \
>     --region eu-west-2 \
>     | jq -r '.LogResult' \
>     | base64 --decode
START RequestId: 615bcb10-2f46-4aae-afb5-96f37112566f Version: $LATEST
[vault-lambda-extension] 2020/10/08 13:13:05 Received event
[vault-lambda-extension] 2020/10/08 13:13:05 Waiting for event...
[runtime] Received invocation: {}
[runtime] Executing function: main
[main] Received: 
[main] Reading file /tmp/vault_secret.json
[main] raw token: <scrubbed>
[main] users: 
[main]      vaultadmin
[main]      rdsadmin
[main]      v-aws-tomh-lambda-f-tzZvSAbVS5Yg4CH7OPBk-1602162785
END RequestId: 615bcb10-2f46-4aae-afb5-96f37112566f
REPORT RequestId: 615bcb10-2f46-4aae-afb5-96f37112566f  Duration: 1203.78 ms    Billed Duration: 1700 ms        Memory Size: 128 MB     Max Memory Used: 61 MB  Init Duration: 417.06 ms
```