### PR TITLE
adding support of eu-north-1(Stockholm) region

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ arn:aws:lambda:us-east-1:634166935893:layer:vault-lambda-extension:6
 ```
 
 Where region may be any of `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`,
-`ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `eu-central-1`,
+`ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `eu-central-1`, `eu-north-1`,
 `eu-west-1`, `eu-west-2`, `eu-west-3`, `sa-east-1`, `us-east-1`, `us-east-2`,
 `us-west-1`, `us-west-2`.
 

--- a/publish-layers.sh
+++ b/publish-layers.sh
@@ -27,6 +27,7 @@ REGIONS=(
   ap-southeast-2
   ca-central-1
   eu-central-1
+  eu-north-1
   eu-west-1
   eu-west-2
   eu-west-3


### PR DESCRIPTION
* AWS Lambda Extensions API is also available in eu-north-1(Stockholm) region, so it would be nice to have official Hashicorp's Lambda layer presented there as well 