### PR TITLE
Add quick-start db_instance_type variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vault-lambda-extension
 
-This repository contains the source code for Hashicorp's Vault AWS Lambda extension.
+This repository contains the source code for HashiCorp's Vault AWS Lambda extension.
 The extension utilizes the AWS Lambda Extensions API to read secrets from your
 Vault deployment and write the result to disk before the Lambda function itself
 starts to execute. To use it, include the following ARN as a layer in your

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -1,13 +1,16 @@
 # Vault Lambda extension Quick Start
 
-Creates the infrastructure required for running a demo of the Vault Lambda extension.
-All of the infrastructure is created in `us-east-1` by default, unless you
-specify `-var aws_region=...` during `terraform apply`.
+This quick start folder has terraform and an example function for creating all the
+infrastructure you need to run a demo of the Vault Lambda extension. By default,
+the infrastructure is created in `us-east-1`. See [variables.tf](terraform/variables.tf)
+for the available variables, including region and instance types.
 
-* An EC2 instance with a vault server running on it with auto-unseal from KMS
+The terraform will create:
+
+* An EC2 instance with a configured Vault server
 * A new SSH key pair used to SSH into the instance
-* IAM role for the Lambda to run as, which will be able to auth against the Vault instance using AWS IAM auth
-* Configures Vault
+* IAM role for the Lambda to run as, configured for AWS IAM auth on Vault
+* An RDS database for which Vault can manage dynamic credentials
 * A Lambda function which requests database credentials from the extension and then uses them to list users on the database
 
 **NB: This demo will create real infrastructure in AWS with an associated

--- a/quick-start/terraform/rds.tf
+++ b/quick-start/terraform/rds.tf
@@ -8,7 +8,7 @@ resource "aws_db_instance" "main" {
   storage_type           = "gp2"
   engine                 = "postgres"
   engine_version         = "12.3"
-  instance_class         = "db.t2.micro"
+  instance_class         = var.db_instance_type
   name                   = "lambdadb"
   username               = "vaultadmin"
   password               = random_password.password.result

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -17,3 +17,8 @@ variable "vault_zip_file" {
 variable "instance_type" {
   default = "t2.micro"
 }
+
+# DB instance size
+variable "db_instance_type" {
+  default = "db.t2.micro"
+}


### PR DESCRIPTION
Following on from #10, where I realised our quick-start folder's default instance sizes don't exist in `eu-north-1`.

Add a `db_instance_type` variable and also add a little note to the readme to make people aware of the other variables available.