### PR TITLE
Fix/quick start

### DIFF
--- a/quick-start/demo-function/main.go
+++ b/quick-start/demo-function/main.go
@@ -44,10 +44,10 @@ func HandleRequest(ctx context.Context, payload Payload) error {
 	}
 
 	// read token
-	tokenRaw, err := ioutil.ReadFile("/tmp/vault/token")
-	if err != nil {
-		return fmt.Errorf("error reading file: %w", err)
-	}
+	// tokenRaw, err := ioutil.ReadFile("/tmp/vault/token")
+	// if err != nil {
+	// 	return fmt.Errorf("error reading file: %w", err)
+	// }
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {

--- a/quick-start/terraform/aws.tf
+++ b/quick-start/terraform/aws.tf
@@ -26,3 +26,51 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+resource "aws_internet_gateway" "gate" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "vault-lamba-vpc-gate"
+  }
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "vault-lamba-db-vpc"
+  }
+}
+
+resource "aws_subnet" "first_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet_cidr_one
+  availability_zone       = var.aws_zone
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "vault-lamba-db-subnet"
+  }
+}
+
+resource "aws_subnet" "second_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet_cidr_two
+  availability_zone       = var.aws_zone_alternative
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "vault-lamba-db-subnet-alternative"
+  }
+}
+
+
+resource "aws_db_subnet_group" "main_db" {
+  name       = "main"
+  subnet_ids = [ aws_subnet.first_subnet.id , aws_subnet.second_subnet.id ]
+
+  tags = {
+    Name = "My DB subnet"
+  }
+}

--- a/quick-start/terraform/rds.tf
+++ b/quick-start/terraform/rds.tf
@@ -15,4 +15,5 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
   publicly_accessible    = true
+  db_subnet_group_name   = aws_db_subnet_group.main_db.name
 }

--- a/quick-start/terraform/security-groups.tf
+++ b/quick-start/terraform/security-groups.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "vault-server" {
   name        = "${var.environment_name}-vault-server-sg"
   description = "SSH and Internal Traffic"
+  vpc_id      = aws_vpc.vpc.id
 
   tags = {
     Name = var.environment_name
@@ -49,6 +50,7 @@ resource "aws_security_group" "vault-server" {
 resource "aws_security_group" "rds" {
   name        = "${var.environment_name}-rds-sg"
   description = "Postgres traffic"
+  vpc_id      = aws_vpc.vpc.id
 
   tags = {
     Name = var.environment_name

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -3,6 +3,15 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
+# AWS zone
+variable "aws_zone" {
+  default = "us-east-1a"
+}
+
+variable "aws_zone_alternative" {
+  default = "us-east-1b"
+}
+
 # All resources will be tagged with this
 variable "environment_name" {
   default = "vault-lambda-extension-demo"
@@ -21,4 +30,22 @@ variable "instance_type" {
 # DB instance size
 variable "db_instance_type" {
   default = "db.t2.micro"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR of the VPC"
+  default     = "172.30.0.0/16"
+}
+
+variable "subnet_cidr_one" {
+  type        = string
+  description = "CIDR of the VPC"
+  default     = "172.30.1.0/24"
+}
+
+variable "subnet_cidr_two" {
+  type        = string
+  description = "CIDR of the VPC"
+  default     = "172.30.2.0/24"
 }

--- a/quick-start/terraform/vault-server.tf
+++ b/quick-start/terraform/vault-server.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "vault-server" {
   instance_type               = var.instance_type
   key_name                    = aws_key_pair.main.key_name
   vpc_security_group_ids      = [aws_security_group.vault-server.id]
+  subnet_id                   = aws_subnet.first_subnet.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.vault-server.id
 


### PR DESCRIPTION
Fixes RDS requirement of VPC/Subnet/Gateway

- RDS wanted two subnets
- Expanded the VPC
- Created two subnets
- Internet Gateway was required
- Adds the Vault server to Subnet

Currently failing reaching the Vault server. It's not reachable at all.

```shell
aws_instance.vault-server (remote-exec): Connecting to remote host via SSH...
aws_instance.vault-server (remote-exec):   Host: 54.146.237.94
aws_instance.vault-server (remote-exec):   User: ubuntu
aws_instance.vault-server (remote-exec):   Password: false
aws_instance.vault-server (remote-exec):   Private key: true
aws_instance.vault-server (remote-exec):   Certificate: false
aws_instance.vault-server (remote-exec):   SSH Agent: true
aws_instance.vault-server (remote-exec):   Checking Host Key: false
aws_instance.vault-server: Still creating... [2m30s elapsed]
aws_instance.vault-server: Still creating... [2m40s elapsed]
aws_instance.vault-server: Still creating... [2m50s elapsed]
```