### PR TITLE
Add server mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Server mode: The extension now starts a Vault API proxy at 127.0.0.1:8200.
+
 ## v0.2.0 (January 20th, 2021)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 FEATURES:
 
-* Server mode: The extension now starts a Vault API proxy at 127.0.0.1:8200.
+* Server mode: The extension now starts a Vault API proxy at `http://127.0.0.1:8200`. [[GH-27](https://github.com/hashicorp/vault-lambda-extension/pull/27)]
+  * **Breaking change:** The extension no longer writes a Vault token to disk.
 
 ## v0.2.0 (January 20th, 2021)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # vault-lambda-extension
 
 This repository contains the source code for HashiCorp's Vault AWS Lambda extension.
-The extension utilizes the AWS Lambda Extensions API to read secrets from your
-Vault deployment and write the result to disk before the Lambda function itself
-starts to execute. To use it, include the following ARN as a layer in your
-Lambda function:
+The extension utilizes the AWS Lambda Extensions API to help your Lambda function
+read secrets from your Vault deployment. To use it, include the following ARN as a
+layer in your Lambda function:
 
 ```text
 arn:aws:lambda:us-east-1:634166935893:layer:vault-lambda-extension:7
@@ -16,8 +15,14 @@ Where region may be any of `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`,
 `us-west-1`, `us-west-2`.
 
 The extension authenticates with Vault using [AWS IAM auth][vault-aws-iam-auth],
-and writes the result as JSON to disk. It also writes a vault token to
-`/tmp/vault/token`. All configuration is supplied via environment variables.
+and all configuration is supplied via environment variables. There are two methods
+to read secrets, which can both be used side-by-side:
+
+* Configure environment variables such as `VAULT_SECRET_PATH` for the extension
+  to read a secret and write it to disk.
+* Make unauthenticated requests to the extension's local server at
+  `http://127.0.0.1:8200`, which will add an authentication header and proxy to
+  the configured `VAULT_ADDR`.
 
 ## Getting Started
 
@@ -72,18 +77,23 @@ material from `/tmp/vault/secret.json`. The exact contents of the JSON object
 will depend on the secret read, but its schema is the [Secret struct][vault-api-secret-struct]
 from the Vault API module.
 
+Alternatively, you can send normal Vault API requests over HTTP to the local
+proxy at `http://127.0.0.1:8200`, and the extension will add authentication
+before forwarding the request. Vault responses will be returned unmodified.
+
 ## Configuration
 
 The extension is configured via [Lambda environment variables][lambda-env-vars].
 Most of the [Vault CLI client's environment variables][vault-env-vars] are available,
 as well as some additional variables to configure auth, which secret(s) to read and
-where to write secrets. At least one valid secret to read must be specified.
+where to write secrets.
 
 Environment variable    | Description | Required | Example value
 ------------------------|-------------|----------|--------------
 `VAULT_ADDR`            | Vault address to connect to | Yes | `https://x.x.x.x:8200`
 `VAULT_AUTH_PROVIDER`   | Name of the configured AWS IAM auth route on Vault | Yes | `aws`
 `VAULT_AUTH_ROLE`       | Vault role to authenticate as | Yes | `lambda-app`
+`VAULT_IAM_SERVER_ID`   | Value to pass to the Vault server via the [`X-Vault-AWS-IAM-Server-ID` HTTP Header for AWS Authentication](https://www.vaultproject.io/api-docs/auth/aws#iam_server_id_header_value) | No | `vault.example.com`
 `VAULT_SECRET_PATH`     | Secret path to read, written to `/tmp/vault/secret.json` unless `VAULT_SECRET_FILE` is specified | No | `database/creds/lambda-app`
 `VAULT_SECRET_FILE`     | Path to write the JSON response for `VAULT_SECRET_PATH` | No | `/tmp/db.json`
 `VAULT_SECRET_PATH_FOO` | Additional secret path to read, where FOO can be any name, as long as a matching `VAULT_SECRET_FILE_FOO` is specified | No | `secret/lambda-app/token`
@@ -101,7 +111,6 @@ Environment variable    | Description | Required | Example value
 `VAULT_CLIENT_CERT`     | Path to a PEM-encoded client certificate on the local disk | No | `/tmp/client.crt`
 `VAULT_CLIENT_KEY`      | Path to an unencrypted, PEM-encoded private key on disk which corresponds to the matching client certificate | No | `/tmp/client.key`
 `VAULT_CLIENT_TIMEOUT`  | Timeout for Vault requests. Default value is 60s. Ignored by proxy server. **Any value over 10s will exceed the Extensions API timeout and therefore have no effect** | No | `5s`
-`VAULT_IAM_SERVER_ID`   | Value to pass to the Vault server via the [`X-Vault-AWS-IAM-Server-ID` HTTP Header for AWS Authentication](https://www.vaultproject.io/api-docs/auth/aws#iam_server_id_header_value) | No | `vault.example.com`
 `VAULT_MAX_RETRIES`     | Maximum number of retries on `5xx` error codes. Defaults to 2. Ignored by proxy server | No | `2`
 `VAULT_SKIP_VERIFY`     | Do not verify Vault's presented certificate before communicating with it. Setting this variable is not recommended and voids Vault's [security model][vault-security-model]  | No | `true`
 `VAULT_TLS_SERVER_NAME` | Name to use as the SNI host when connecting via TLS | No | `vault.example.com`

--- a/README.md
+++ b/README.md
@@ -100,15 +100,13 @@ Environment variable    | Description | Required | Example value
 `VAULT_CAPATH`          | Path to a _directory_ of PEM-encoded CA certificate files on the local disk | No | `/tmp/certs`
 `VAULT_CLIENT_CERT`     | Path to a PEM-encoded client certificate on the local disk | No | `/tmp/client.crt`
 `VAULT_CLIENT_KEY`      | Path to an unencrypted, PEM-encoded private key on disk which corresponds to the matching client certificate | No | `/tmp/client.key`
-`VAULT_CLIENT_TIMEOUT`  | Timeout for Vault requests. Default value is 60s. **Any value over 10s will exceed the Extensions API timeout and therefore have no effect** | No | `5s`
+`VAULT_CLIENT_TIMEOUT`  | Timeout for Vault requests. Default value is 60s. Ignored by proxy server. **Any value over 10s will exceed the Extensions API timeout and therefore have no effect** | No | `5s`
 `VAULT_IAM_SERVER_ID`   | Value to pass to the Vault server via the [`X-Vault-AWS-IAM-Server-ID` HTTP Header for AWS Authentication](https://www.vaultproject.io/api-docs/auth/aws#iam_server_id_header_value) | No | `vault.example.com`
-`VAULT_MAX_RETRIES`     | Maximum number of retries on `5xx` error codes. Defaults to 2 | No | `2`
+`VAULT_MAX_RETRIES`     | Maximum number of retries on `5xx` error codes. Defaults to 2. Ignored by proxy server | No | `2`
 `VAULT_SKIP_VERIFY`     | Do not verify Vault's presented certificate before communicating with it. Setting this variable is not recommended and voids Vault's [security model][vault-security-model]  | No | `true`
 `VAULT_TLS_SERVER_NAME` | Name to use as the SNI host when connecting via TLS | No | `vault.example.com`
-`VAULT_RATE_LIMIT`      | Only applies to a single invocation of the extension. See [Vault Commands (CLI)][vault-env-vars] documentation for details | No | `10`
-`VAULT_NAMESPACE`       | The namespace to use for the command | No | `education`
-`VAULT_SRV_LOOKUP`      | The Vault client will lookup DNS SRV records for the host. See [Vault Commands (CLI)][vault-env-vars] documentation for details | No | `true`
-`VAULT_MFA`             | MFA credentials. See [Vault Commands (CLI)][vault-env-vars] documentation for details | No | `true`
+`VAULT_RATE_LIMIT`      | Only applies to a single invocation of the extension. See [Vault Commands (CLI)][vault-env-vars] documentation for details. Ignored by proxy server | No | `10`
+`VAULT_NAMESPACE`       | The namespace to use for pre-configured secrets. Ignored by proxy server | No | `education`
 
 ## Limitations
 

--- a/config/config.go
+++ b/config/config.go
@@ -135,10 +135,6 @@ func ParseConfiguredSecrets() ([]ConfiguredSecret, error) {
 		result = append(result, *secret)
 	}
 
-	if len(result) == 0 {
-		resultErr = multierror.Append(resultErr, fmt.Errorf("no valid secrets to read configured"))
-	}
-
 	return result, resultErr
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,7 @@ func TestParseConfiguredSecrets(t *testing.T) {
 		{
 			name:         "Empty environment",
 			expected:     []ConfiguredSecret{},
-			expectErrors: 1,
+			expectErrors: 0,
 		},
 		{
 			name: "Minimal valid config",

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,11 @@ go 1.15
 require (
 	github.com/aws/aws-sdk-go v1.35.3
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/vault/api v1.0.4
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/vault/api v1.0.4
+	github.com/hashicorp/vault/sdk v0.1.13
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/hashicorp/go-retryablehttp v0.5.4 h1:1BZvpawXoJCWX6pNtow9+rpEj+3itIlu
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.1 h1:DMo4fmknnz0E0evoNYnV48RjWndOsmd6OW+09R3cEP8=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -56,6 +58,11 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -67,6 +74,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
+github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -83,6 +92,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -128,9 +139,14 @@ google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -85,9 +85,9 @@ func initialiseExtension(logger *log.Logger, threadFinishedCh chan struct{}) (*h
 
 	client, err := vault.NewClient(logger, vaultAuthRole, vaultAuthProvider, vaultIAMServerID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting client: %s", err)
+		return nil, fmt.Errorf("error getting client: %w", err)
 	} else if client == nil {
-		return nil, fmt.Errorf("nil client returned: %s", err)
+		return nil, fmt.Errorf("nil client returned: %w", err)
 	}
 
 	err = writePreconfiguredSecrets(client)
@@ -118,7 +118,7 @@ func initialiseExtension(logger *log.Logger, threadFinishedCh chan struct{}) (*h
 func writePreconfiguredSecrets(client *api.Client) error {
 	configuredSecrets, err := config.ParseConfiguredSecrets()
 	if err != nil {
-		return fmt.Errorf("failed to parse configured secrets to read: %s", err)
+		return fmt.Errorf("failed to parse configured secrets to read: %w", err)
 	}
 
 	if _, err := os.Stat(config.DefaultSecretDirectory); os.IsNotExist(err) {
@@ -137,7 +137,7 @@ func writePreconfiguredSecrets(client *api.Client) error {
 		// Will block until shutdown event is received or cancelled via the context.
 		secret, err := client.Logical().Read(s.VaultPath)
 		if err != nil {
-			return fmt.Errorf("error reading secret: %s", err)
+			return fmt.Errorf("error reading secret: %w", err)
 		}
 
 		content, err := json.MarshalIndent(secret, "", "  ")

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 func initialiseExtension(logger *log.Logger, threadFinishedCh chan struct{}) (*http.Server, error) {
 	logger.Println("Initialising")
 
-	vaultAddr := os.Getenv("VAULT_ADDR")
+	vaultAddr := os.Getenv(api.EnvVaultAddress)
 	vaultAuthRole := os.Getenv("VAULT_AUTH_ROLE")
 	vaultAuthProvider := os.Getenv("VAULT_AUTH_PROVIDER")
 	vaultIAMServerID := os.Getenv("VAULT_IAM_SERVER_ID") // Optional
@@ -83,7 +83,7 @@ func initialiseExtension(logger *log.Logger, threadFinishedCh chan struct{}) (*h
 		return nil, errors.New("missing VAULT_ADDR, VAULT_AUTH_PROVIDER or VAULT_AUTH_ROLE environment variables")
 	}
 
-	client, err := vault.NewClient(logger, vaultAuthRole, vaultAuthProvider, vaultIAMServerID)
+	client, config, err := vault.NewClient(logger, vaultAuthRole, vaultAuthProvider, vaultIAMServerID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting client: %w", err)
 	} else if client == nil {
@@ -99,7 +99,7 @@ func initialiseExtension(logger *log.Logger, threadFinishedCh chan struct{}) (*h
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on port 8200: %w", err)
 	}
-	srv := server.New(logger, client)
+	srv := server.New(logger, config, client.Token())
 	go func() {
 		logger.Println("Starting HTTP server...")
 		err = srv.Serve(ln)

--- a/main.go
+++ b/main.go
@@ -42,8 +42,8 @@ func main() {
 	}
 
 	shutdownChannel := make(chan struct{})
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		interruptChannel := make(chan os.Signal, 1)
 		signal.Notify(interruptChannel, syscall.SIGTERM, syscall.SIGINT)
@@ -100,8 +100,8 @@ func runExtension(logger *log.Logger, wg *sync.WaitGroup) (*http.Server, error) 
 		return nil, fmt.Errorf("failed to listen on port 8200: %w", err)
 	}
 	srv := server.New(logger, config, client.Token())
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		logger.Println("Starting HTTP server")
 		err = srv.Serve(ln)

--- a/main.go
+++ b/main.go
@@ -121,18 +121,6 @@ func writePreconfiguredSecrets(client *api.Client) error {
 		return fmt.Errorf("failed to parse configured secrets to read: %w", err)
 	}
 
-	if _, err := os.Stat(config.DefaultSecretDirectory); os.IsNotExist(err) {
-		err = os.MkdirAll(config.DefaultSecretDirectory, 0755)
-		if err != nil {
-			return fmt.Errorf("failed to create directory %s: %s", config.DefaultSecretDirectory, err)
-		}
-	}
-
-	err = ioutil.WriteFile(path.Join(config.DefaultSecretDirectory, "token"), []byte(client.Token()), 0644)
-	if err != nil {
-		return err
-	}
-
 	for _, s := range configuredSecrets {
 		// Will block until shutdown event is received or cancelled via the context.
 		secret, err := client.Logical().Read(s.VaultPath)

--- a/server/server.go
+++ b/server/server.go
@@ -12,12 +12,10 @@ import (
 )
 
 // New returns an unstarted HTTP server with health and proxy handlers.
-func New(logger *log.Logger, proxyAddr string, vaultClient *api.Client) *http.Server {
+func New(logger *log.Logger, vaultClient *api.Client) *http.Server {
 	mux := http.ServeMux{}
-	mux.HandleFunc("/_health", healthHandler)
 	mux.HandleFunc("/", proxyHandler(logger, vaultClient))
 	srv := http.Server{
-		Addr:    proxyAddr,
 		Handler: &mux,
 	}
 
@@ -104,10 +102,4 @@ func proxyRequest(client *api.Client, r *http.Request, body []byte) (*api.Respon
 		return nil, errors.New(errString)
 	}
 	return resp, nil
-}
-
-// healthHandler is used to check that the server is running and accepting
-// connections before notifying the extensions API that we're initialised.
-func healthHandler(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(200)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// New returns an unstarted HTTP server with health and proxy handlers.
+func New(logger *log.Logger, proxyAddr string, vaultClient *api.Client) *http.Server {
+	mux := http.ServeMux{}
+	mux.HandleFunc("/_health", healthHandler)
+	mux.HandleFunc("/", proxyHandler(logger, vaultClient))
+	srv := http.Server{
+		Addr:    proxyAddr,
+		Handler: &mux,
+	}
+
+	return &srv
+}
+
+// The proxyHandler is based on the Send function from Vault Agent's proxy:
+// https://github.com/hashicorp/vault/blob/22b486b651b8956d32fb24e77cef4050df7094b6/command/agent/cache/api_proxy.go
+func proxyHandler(logger *log.Logger, vaultClient *api.Client) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			cl, err := vaultClient.Clone()
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			cl.SetToken(vaultClient.Token())
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+
+			logger.Printf("Proxying %s %s\n", r.Method, r.URL.Path)
+			resp, err := proxyRequest(cl, r, body)
+			if err != nil {
+				if resp != nil && resp.Error() != nil {
+					// If we got an api.Response error, we'll just return that below without modification.
+				} else {
+					http.Error(w, err.Error(), 502)
+					return
+				}
+			}
+
+			w.WriteHeader(resp.StatusCode)
+			headers := w.Header()
+			for k, vv := range resp.Header {
+				for _, v := range vv {
+					headers.Add(k, v)
+				}
+			}
+			defer resp.Body.Close()
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				http.Error(w, "failed to write response back to requester", 500)
+				return
+			}
+			logger.Printf("Successfully proxied %s %s\n", r.Method, r.URL.Path)
+		default:
+			http.Error(w, fmt.Sprintf("unsupported method for vault-lambda-extension: %s", r.Method), 400)
+			return
+		}
+	}
+}
+
+func proxyRequest(client *api.Client, r *http.Request, body []byte) (*api.Response, error) {
+	// http.Transport will transparently request gzip and decompress the response, but only if
+	// the client doesn't manually set the header. Removing any Accept-Encoding header allows the
+	// transparent compression to occur.
+	r.Header.Del("Accept-Encoding")
+	client.SetHeaders(r.Header)
+
+	fwReq := client.NewRequest(r.Method, r.URL.Path)
+	fwReq.BodyBytes = body
+
+	query := r.URL.Query()
+	if len(query) > 0 {
+		fwReq.Params = query
+	}
+
+	resp, err := client.RawRequestWithContext(r.Context(), fwReq)
+	if err != nil {
+		errString := fmt.Sprintf("failed to proxy request: %s", err)
+		if resp != nil {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			errString += fmt.Sprintf("\n\n(%d) %s", resp.StatusCode, string(body))
+			if err != nil {
+				errString += fmt.Sprintf("\n\nfailed to read response body: %s", err)
+			}
+		}
+		return nil, errors.New(errString)
+	}
+	return resp, nil
+}
+
+// healthHandler is used to check that the server is running and accepting
+// connections before notifying the extensions API that we're initialised.
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(200)
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -31,17 +31,17 @@ func TestProxy(t *testing.T) {
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	proxy := New(log.New(ioutil.Discard, "[proxy server] ", 0), ln.Addr().String(), cl)
+	proxy := New(log.New(ioutil.Discard, "[proxy server] ", 0), cl)
 	go func() {
 		_ = proxy.Serve(ln)
 	}()
 
 	proxyClient, err := api.NewClient(&api.Config{
-		Address: "http://" + proxy.Addr,
+		Address: "http://" + ln.Addr().String(),
 	})
 
 	t.Run("_health endpoint works", func(t *testing.T) {
-		resp, err := http.Get(fmt.Sprintf("http://%s/_health", proxy.Addr))
+		resp, err := http.Get(fmt.Sprintf("http://%s/_health", ln.Addr().String()))
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 	})
@@ -54,7 +54,7 @@ func TestProxy(t *testing.T) {
 				},
 			},
 		}
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/secret/data/foo", proxy.Addr))
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/secret/data/foo", ln.Addr().String()))
 		require.NoError(t, err)
 		if resp.StatusCode != 200 {
 			body, err := ioutil.ReadAll(resp.Body)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+)
+
+type vaultResponse struct {
+	secret *api.Secret
+	err    error
+	code   int
+}
+
+var fakeVaultResponse vaultResponse
+
+func TestProxy(t *testing.T) {
+	vault := fakeVault()
+	cl, err := api.NewClient(&api.Config{
+		Address: vault.URL,
+	})
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	proxy := New(log.New(ioutil.Discard, "[proxy server] ", 0), ln.Addr().String(), cl)
+	go func() {
+		_ = proxy.Serve(ln)
+	}()
+
+	proxyClient, err := api.NewClient(&api.Config{
+		Address: "http://" + proxy.Addr,
+	})
+
+	t.Run("_health endpoint works", func(t *testing.T) {
+		resp, err := http.Get(fmt.Sprintf("http://%s/_health", proxy.Addr))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+	})
+
+	t.Run("happy path bare http client", func(t *testing.T) {
+		fakeVaultResponse = vaultResponse{
+			secret: &api.Secret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		}
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/secret/data/foo", proxy.Addr))
+		require.NoError(t, err)
+		if resp.StatusCode != 200 {
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			t.Fatal("Non-200 status code from proxy", string(body))
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var secret api.Secret
+		require.NoError(t, json.Unmarshal(body, &secret), string(body))
+		require.Equal(t, "bar", secret.Data["foo"])
+	})
+
+	t.Run("happy path with vault client", func(t *testing.T) {
+		fakeVaultResponse = vaultResponse{
+			secret: &api.Secret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		}
+		resp, err := proxyClient.Logical().Read("secret/data/foo")
+		require.NoError(t, err)
+		require.Equal(t, "bar", resp.Data["foo"])
+	})
+}
+
+func fakeVault() *httptest.Server {
+	vaultResponsePtr := &fakeVaultResponse
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if vaultResponsePtr.err != nil {
+			http.Error(w, vaultResponsePtr.err.Error(), vaultResponsePtr.code)
+			return
+		}
+		bytes, err := json.Marshal(vaultResponsePtr.secret)
+		if err != nil {
+			http.Error(w, "failed to marshal JSON", 500)
+			return
+		}
+		_, err = w.Write(bytes)
+		if err != nil {
+			http.Error(w, "failed to write response", 500)
+			return
+		}
+	}))
+}

--- a/test/api/Dockerfile
+++ b/test/api/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.mirror.hashicorp.services/golang:1.15-alpine3.13 as builder
+
+COPY . /go/src/
+WORKDIR /go/src/
+
+RUN go build -o /bin/api main.go
+
+FROM docker.mirror.hashicorp.services/alpine:3.13
+
+COPY --from=builder /bin/api /bin/api
+
+ENTRYPOINT /bin/api

--- a/test/api/README.md
+++ b/test/api/README.md
@@ -1,0 +1,15 @@
+# `test/api`
+
+In AWS Lambda functions, both extensions and the function itself operate by
+requesting the next event from an HTTP API in an infinite loop. Each event
+returned is typically either an invocation, or for extensions, it could also
+be a request to shutdown.
+
+This folder contains a small API server to mock that AWS Lambda API for the
+purpose of local/CI integration tests. It's intentionally as small and as
+simplistic as possible to support the bare minimum to run extension
+binaries.
+
+In addition to the AWS Lambda APIs, there is also a /_sync endpoint used
+within the tests to synchronise on events such as the extension signalling
+readiness.

--- a/test/api/main.go
+++ b/test/api/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+)
+
+func main() {
+	// Extension API endpoints.
+	http.HandleFunc("/2020-01-01/extension/register", extensionRegisterHandler)
+	http.HandleFunc("/2020-01-01/extension/event/next", extensionEventHandler())
+
+	// Test framework synchronisation endpoints.
+	// GETs will wait for a POST to the path.
+	// POSTs return immediately.
+	http.HandleFunc("/_sync/extension-initialised", syncHandler())
+	http.HandleFunc("/_sync/shutdown-extension", syncHandler())
+
+	log.Println("Mock API listening on port 80")
+	err := http.ListenAndServe("0.0.0.0:80", nil)
+	if err != nil {
+		log.Printf("Error shutting down: %s\n", err)
+	}
+}
+
+// extensionRegisterHandler just answers OK.
+func extensionRegisterHandler(w http.ResponseWriter, _ *http.Request) {
+	log.Println("/extension/register API invoked")
+	_, err := w.Write([]byte("{}"))
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+}
+
+// extensionEventHandler returns an INVOKE event and then a SHUTDOWN event, with a wait in between.
+func extensionEventHandler() func(w http.ResponseWriter, _ *http.Request) {
+	var mutex sync.Mutex
+	var calls int
+	return func(w http.ResponseWriter, _ *http.Request) {
+		// Make this stateful handler explicitly single threaded.
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		log.Println("/extension/event/next API invoked")
+		calls++
+		switch calls {
+		case 1:
+			// Tell the API that the extension has finished initialising.
+			_, err := http.Post("http://127.0.0.1:80/_sync/extension-initialised", "", nil)
+			if err != nil {
+				http.Error(w, "Failed to create extension initialised event", 500)
+				return
+			}
+			_, err = w.Write([]byte(`{"eventType":"INVOKE"}`))
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			log.Println("INVOKE event returned")
+		case 2:
+			// First, wait for shutdown to get requested.
+			_, err := http.Get("http://127.0.0.1:80/_sync/shutdown-extension")
+			if err != nil {
+				http.Error(w, "Failed to wait for shutdown event", 500)
+				return
+			}
+			_, err = w.Write([]byte(`{"eventType":"SHUTDOWN"}`))
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			log.Println("SHUTDOWN event returned")
+		default:
+			http.Error(w, "only expected /event/next endpoint to be called twice", 400)
+		}
+	}
+}
+
+func syncHandler() func(http.ResponseWriter, *http.Request) {
+	ch := make(chan struct{})
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s to %s\n", r.Method, r.URL.Path)
+		switch r.Method {
+		case "POST":
+			ch <- struct{}{}
+		case "GET":
+			<-ch
+		default:
+			http.Error(w, fmt.Sprintf("Unexpected sync method %s", r.Method), 400)
+		}
+	}
+}

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: api/
+  lambda:
+    build:
+      context: ../
+      dockerfile: test/lambda/Dockerfile
+    depends_on:
+      - api
+      - vault
+    environment:
+      # Configuration for vault-lambda-extension
+      - VAULT_ADDR=http://vault:8200
+      - VAULT_AUTH_PROVIDER=aws
+      - VAULT_AUTH_ROLE=lambda-demo-function
+      # Configuration for the AWS extension client
+      - AWS_LAMBDA_RUNTIME_API=api
+      # Auth for vault-lambda-extension
+      # These key-only env vars use the host machine's values
+      - AWS_ROLE_ARN
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+  vault:
+    image: docker.mirror.hashicorp.services/vault:1.6.2
+    command: vault server -dev -log-level=err
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=root
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200

--- a/test/lambda/Dockerfile
+++ b/test/lambda/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.mirror.hashicorp.services/vault:1.6.2 as vault
+
+FROM docker.mirror.hashicorp.services/golang:1.15-alpine3.13 as builder
+
+COPY . /go/src/
+WORKDIR /go/src/
+
+RUN go build -o /bin/vault-lambda-extension main.go
+
+FROM docker.mirror.hashicorp.services/alpine:3.13
+
+RUN apk update && apk add curl
+
+COPY --from=vault /bin/vault /bin/vault
+COPY --from=builder /bin/vault-lambda-extension /opt/extensions/vault-lambda-extension
+COPY test/lambda/runtime.sh /bin/runtime.sh
+
+ENTRYPOINT ["/bin/runtime.sh"]

--- a/test/lambda/runtime.sh
+++ b/test/lambda/runtime.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# This script is for local integration testing.
+# It simulates a basic version of how Lambda runs a function that includes extensions.
+
+set -euo pipefail
+
+function configure_vault() {
+    # Wait until vault is up (retry up to 10 x 1s).
+    curl --silent --retry 10 --retry-connrefused --retry-delay 1 $VAULT_ADDR > /dev/null 2>&1
+
+    export VAULT_TOKEN=root
+    vault policy write test_policy - <<EOF
+    path "secret/*" {
+        capabilities = ["read", "list"]
+    }
+EOF
+    vault auth enable aws
+    vault write -force auth/aws/config/client
+    vault write auth/aws/role/lambda-demo-function \
+        auth_type=iam \
+        policies=test_policy \
+        ttl=1h \
+        resolve_aws_unique_ids=false \
+        bound_iam_principal_arn="${AWS_ROLE_ARN}"
+    vault kv put secret/foo bar=baz
+    unset VAULT_TOKEN
+}
+
+# Configure Vault
+echo "Configuring Vault"
+configure_vault
+
+# Run the extension in the background
+echo "Running extension"
+/opt/extensions/vault-lambda-extension 2>&1 | tee /tmp/vault-lambda-extension.log &
+EXTENSION_PID=$!
+
+# Wait for the extension to call /event/next API endpoint, signalling the end of the
+# extension initialisation phase.
+echo "Waiting for the extension to signal readiness"
+curl --silent --max-time 10 api:80/_sync/extension-initialised
+
+# Here is where the function code itself would now be invoked.
+# Instead of running a function, we run some tests on the extension.
+
+# Check the extension proxy is working (auth-less call to localhost).
+echo "Reading secret via proxy server"
+curl --silent -H "X-Vault-Request: true" http://127.0.0.1:8200/v1/secret/data/foo
+
+# Tell the API that we're ready for it to send the SHUTDOWN event to the extension.
+echo "Signalling shutdown to extension"
+curl --silent --request POST api:80/_sync/shutdown-extension
+
+# Wait for the extension to finish shutting down.
+wait $EXTENSION_PID

--- a/vault/client.go
+++ b/vault/client.go
@@ -14,10 +14,14 @@ import (
 
 // NewClient uses the AWS IAM auth method configured in a Vault cluster to
 // authenticate the execution role and create a Vault API client.
-func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaultIAMServerID string) (*api.Client, error) {
-	vaultClient, err := api.NewClient(nil)
+func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaultIAMServerID string) (*api.Client, *api.Config, error) {
+	config := api.DefaultConfig()
+	if config.Error != nil {
+		return nil, nil, fmt.Errorf("error making default vault config for extension: %w", config.Error)
+	}
+	vaultClient, err := api.NewClient(config)
 	if err != nil {
-		return nil, fmt.Errorf("error making extension: %w", err)
+		return nil, nil, fmt.Errorf("error making extension: %w", err)
 	}
 
 	ses := session.Must(session.NewSession())
@@ -31,17 +35,17 @@ func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaul
 	}
 
 	if signErr := req.Sign(); signErr != nil {
-		return nil, signErr
+		return nil, nil, signErr
 	}
 
 	headers, err := json.Marshal(req.HTTPRequest.Header)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	body, err := ioutil.ReadAll(req.HTTPRequest.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	d := make(map[string]interface{})
@@ -54,19 +58,19 @@ func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaul
 	logger.Println("attemping Vault login...")
 	resp, err := vaultClient.Logical().Write(fmt.Sprintf("auth/%s/login", vaultAuthProvider), d)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("got no response from the %s authentication provider", vaultAuthProvider)
+		return nil, nil, fmt.Errorf("got no response from the %s authentication provider", vaultAuthProvider)
 	}
 
 	token, err := parseToken(resp)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing token: %s", err)
+		return nil, nil, fmt.Errorf("error parsing token: %s", err)
 	}
 	vaultClient.SetToken(token)
 
-	return vaultClient, nil
+	return vaultClient, config, nil
 }
 
 func parseToken(resp *api.Secret) (string, error) {

--- a/vault/client.go
+++ b/vault/client.go
@@ -14,7 +14,7 @@ import (
 
 // NewClient uses the AWS IAM auth method configured in a Vault cluster to
 // authenticate the execution role and create a Vault API client.
-func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaultIamServerId string) (*api.Client, error) {
+func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaultIAMServerID string) (*api.Client, error) {
 	vaultClient, err := api.NewClient(nil)
 	if err != nil {
 		return nil, fmt.Errorf("error making extension: %w", err)
@@ -26,8 +26,8 @@ func NewClient(logger *log.Logger, vaultAuthRole, vaultAuthProvider string, vaul
 	// ignore out
 	req, _ := stsSvc.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
 
-	if vaultIamServerId != "" {
-		req.HTTPRequest.Header.Add("X-Vault-AWS-IAM-Server-ID", vaultIamServerId)
+	if vaultIAMServerID != "" {
+		req.HTTPRequest.Header.Add("X-Vault-AWS-IAM-Server-ID", vaultIAMServerID)
 	}
 
 	if signErr := req.Sign(); signErr != nil {


### PR DESCRIPTION
Addresses #13.

* Start local HTTP server at 127.0.0.1:8200 with proxy handler
  * The proxy will add authentication to requests based on the IAM auth configured via environment variables
* Add local integration test with docker-compose
* No longer require >=1 secrets configured via env var

To run the integration test on your machine, set the following env vars:
`AWS_ROLE_ARN` as the role you want IAM auth to identify you as, e.g. `arn:aws:iam::<account number>:role/vault_team_dev-developer`
`AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID` and `AWS_SESSION_TOKEN` with some AWS credentials that can access the above role.

Then from the root of the repo:

```bash
docker-compose --file test/docker-compose.yaml up --abort-on-container-exit --exit-code-from lambda
```

Still TODO:
- [x] Finalise error codes/error handling in the proxy handler
- [x] More unit test cases
- [x] Documentation updates
- [x] Finish changelog entry