### PR TITLE
Bump quick-start Vault version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Use client-controlled consistency when writing secrets to disk to reliably support performance standbys/replicas. [[GH-47](https://github.com/hashicorp/vault-lambda-extension/pull/47)]
+
 ## 0.4.0 (July 1, 2021)
 
 FEATURES:

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "environment_name" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.5.4/vault_1.5.4_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.8.1/vault_1.8.1_linux_amd64.zip"
 }
 
 # Instance size


### PR DESCRIPTION
A little bit of pre-release book keeping.

* Update change log
* Update Vault version used in quick-start