### PR TITLE
VAULT_SECRET_DATA_JSON to output just secret JSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Environment variable    | Description | Required | Example value
 `VAULT_NAMESPACE`       | The namespace to use for pre-configured secrets. Ignored by proxy server | No | `education`
 `VAULT_DEFAULT_CACHE_TTL` | The time to live configuration (aka, TTL) of the cache used by proxy server. Must have a unit and be parsable as a time.Duration. Required for caching to be enabled. | No | `15m`
 `VAULT_DEFAULT_CACHE_ENABLED` | Enable caching for all requests, without needing to set the X-Vault-Cache-Control header for each request. Must be set to a boolean value. | No | `true`
+`VAULT_SECRET_DATA_JSON` | If set to `true`, the extension will return just the data portion of the secret, instead of the entire nested JSON structure. | No | `true`
 
 ### AWS STS client configuration
 

--- a/main.go
+++ b/main.go
@@ -173,8 +173,12 @@ func writePreconfiguredSecrets(client *api.Client) error {
 		if err != nil {
 			return fmt.Errorf("error reading secret: %w", err)
 		}
-
-		content, err := json.MarshalIndent(secret, "", "  ")
+		var data interface{}
+		data = secret
+		if os.Getenv("VAULT_SECRET_DATA_JSON") == "true" {
+			data = secret.Data
+		}
+		content, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds a new optional environment variable `VAULT_SECRET_DATA_JSON` (boolean `true` / `false`, default `false`).

If set to `true`, the extension will write just the `secret.Data` JSON, rather than the full `api.Secret` object with the nested Data field.

This is useful where the JSON object in Vault must be consumed as-is, such as with GCP Service Accounts. 