### PR TITLE
[RelAPI Onboarding] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,3 @@
+url_license = "https://github.com/hashicorp/vault-lambda-extension/blob/main/LICENSE"
+url_project_website = "https://learn.hashicorp.com/tutorials/vault/aws-lambda?in=vault/app-integration"
+url_source_repository = "https://github.com/hashicorp/vault-lambda-extension"

--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,3 +1,3 @@
 url_license = "https://github.com/hashicorp/vault-lambda-extension/blob/main/LICENSE"
-url_project_website = "https://learn.hashicorp.com/tutorials/vault/aws-lambda?in=vault/app-integration"
+url_project_website = "https://github.com/hashicorp/vault-lambda-extension#readme"
 url_source_repository = "https://github.com/hashicorp/vault-lambda-extension"


### PR DESCRIPTION
👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged now, but will not have any effect until after the RelAPI launch. Similar additions are being added across all projects that publish to