### PR TITLE
Update quick start

### DIFF
--- a/quick-start/demo-function/Dockerfile
+++ b/quick-start/demo-function/Dockerfile
@@ -1,7 +1,7 @@
 # Based on vanilla Dockerfile to build a Golang image from:
 # https://docs.aws.amazon.com/lambda/latest/dg/go-image.html
 # The main modification is to copy the extension binary into the image.
-FROM golang:1.16.4 as build
+FROM golang:1.17.8 as build
 
 # Cache dependencies
 ADD go.mod go.sum /go/src/vault-lambda-extension/

--- a/quick-start/terraform/lambda.tf
+++ b/quick-start/terraform/lambda.tf
@@ -5,7 +5,8 @@ resource "aws_lambda_function" "function" {
   filename      = "../demo-function/demo-function.zip"
   handler       = "main"
   runtime       = "provided.al2"
-  layers        = ["arn:aws:lambda:${var.aws_region}:634166935893:layer:vault-lambda-extension:11"]
+  architectures = ["x86_64"]
+  layers        = ["arn:aws:lambda:${var.aws_region}:634166935893:layer:vault-lambda-extension:12"]
 
   environment {
     variables = {

--- a/quick-start/terraform/rds.tf
+++ b/quick-start/terraform/rds.tf
@@ -7,7 +7,7 @@ resource "aws_db_instance" "main" {
   allocated_storage      = 20
   storage_type           = "gp2"
   engine                 = "postgres"
-  engine_version         = "12.3"
+  engine_version         = "12.9"
   instance_class         = var.db_instance_type
   name                   = "lambdadb"
   username               = "vaultadmin"

--- a/quick-start/terraform/rds.tf
+++ b/quick-start/terraform/rds.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "main" {
   engine                 = "postgres"
   engine_version         = "12.9"
   instance_class         = var.db_instance_type
-  name                   = "lambdadb"
+  db_name                = "lambdadb"
   username               = "vaultadmin"
   password               = random_password.password.result
   vpc_security_group_ids = [aws_security_group.rds.id]

--- a/quick-start/terraform/versions.tf
+++ b/quick-start/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     aws = {
-      version = "~> 3.39.0"
+      version = "~> 4.9.0"
     } 
   }
 }


### PR DESCRIPTION
Update the demo container to go 1.17, bump the postgres engine version, and use terraform aws provider 4.9.0 that supports specifying the lambda architecture.