### PR TITLE
Remove unused instance profile

### DIFF
--- a/quick-start/terraform/iam.tf
+++ b/quick-start/terraform/iam.tf
@@ -18,6 +18,7 @@ resource "aws_iam_role_policy" "vault-server" {
   policy = data.aws_iam_policy_document.vault-server.json
 }
 
+# Vault Client (Lambda function) IAM Config
 resource "aws_iam_role" "lambda" {
   name               = "${var.environment_name}-lambda-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_lambda.json

--- a/quick-start/terraform/iam.tf
+++ b/quick-start/terraform/iam.tf
@@ -18,12 +18,6 @@ resource "aws_iam_role_policy" "vault-server" {
   policy = data.aws_iam_policy_document.vault-server.json
 }
 
-# Vault Client (Lambda function) IAM Config
-resource "aws_iam_instance_profile" "lambda" {
-  name = "${var.environment_name}-lambda-instance-profile"
-  role = aws_iam_role.lambda.name
-}
-
 resource "aws_iam_role" "lambda" {
   name               = "${var.environment_name}-lambda-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_lambda.json


### PR DESCRIPTION
It looks like this instance profile isn't being used anywhere.

I was excited because using instance profiles as an auth method is so quick to build out, but it looks like this isn't wired anywhere, and you'll have to use roles for lambda execution (which makes sense).

Am I off base?