### PR TITLE
support VAULT_RUN_MODE envvar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 IMPROVEMENTS:
 * Requests from the extension to Vault now set the User-Agent field accordingly.
+* Introduced a `VAULT_RUN_MODE` environment variable to allow user to run in proxy mode, file mode, or both. 
+  * The default value is 'default', which runs in *both* proxy and file mode.
 
 ## 0.9.0 (February 23, 2023)
 

--- a/internal/config/info.go
+++ b/internal/config/info.go
@@ -4,4 +4,5 @@ const (
 	ExtensionName    = "vault-lambda-extension"
 	ExtensionVersion = "0.9.0"
 	VaultLogLevel    = "VAULT_LOG_LEVEL" // Optional, one of TRACE, DEBUG, INFO, WARN, ERROR, OFF
+	VaultRunMode     = "VAULT_RUN_MODE"
 )

--- a/internal/extension/client.go
+++ b/internal/extension/client.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -89,7 +89,7 @@ func (e *Client) Register(ctx context.Context, filename string) (*RegisterRespon
 		return nil, fmt.Errorf("request failed with status %s", httpRes.Status)
 	}
 	defer httpRes.Body.Close()
-	body, err := ioutil.ReadAll(httpRes.Body)
+	body, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (e *Client) NextEvent(ctx context.Context) (*NextEventResponse, error) {
 		return nil, fmt.Errorf("request failed with status %s", httpRes.Status)
 	}
 	defer httpRes.Body.Close()
-	body, err := ioutil.ReadAll(httpRes.Body)
+	body, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proxy/cache.go
+++ b/internal/proxy/cache.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -74,7 +75,7 @@ func NewCache(cc config.CacheConfig) *Cache {
 // constructs the CacheKey for this request and token and returns the SHA256
 // hash
 func makeRequestHash(logger hclog.Logger, r *http.Request, token string) (string, error) {
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		if r.Body != nil {
 			if err := r.Body.Close(); err != nil {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -81,7 +81,7 @@ func TestProxy(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		var secret api.Secret
 		require.NoError(t, json.Unmarshal(body, &secret), string(body))

--- a/internal/runmode/runmode.go
+++ b/internal/runmode/runmode.go
@@ -29,10 +29,10 @@ func ParseMode(rm string) Mode {
 	return Mode(rm)
 }
 
-func (m Mode) HasModeFile() bool {
+func (m Mode) HasModeProxy() bool {
 	return m == ModeDefault || m == ModeProxy
 }
 
-func (m Mode) HasFileMode() bool {
+func (m Mode) HasModeFile() bool {
 	return m == ModeDefault || m == ModeFile
 }

--- a/internal/runmode/runmode.go
+++ b/internal/runmode/runmode.go
@@ -1,0 +1,38 @@
+// Package runmode determines if the vault lambda extension should run in default mode, file mode, or proxy mode.
+// default mode: uses both file and proxy mode
+// file mode: writes secrets to disk
+// proxy mode: forwards requests to a Vault server
+package runmode
+
+import "strings"
+
+type Mode string
+
+var (
+	ModeDefault Mode = "default"
+	ModeFile    Mode = "file"
+	ModeProxy   Mode = "proxy"
+)
+
+var modes = map[Mode]struct{}{
+	ModeFile:    {},
+	ModeProxy:   {},
+	ModeDefault: {},
+}
+
+func ParseMode(rm string) Mode {
+	_, ok := modes[Mode(strings.ToLower(rm))]
+	if !ok {
+		return ModeDefault
+	}
+
+	return Mode(rm)
+}
+
+func (m Mode) HasModeProxy() bool {
+	return m == ModeDefault || m == ModeProxy
+}
+
+func (m Mode) HasFileMode() bool {
+	return m == ModeDefault || m == ModeFile
+}

--- a/internal/runmode/runmode.go
+++ b/internal/runmode/runmode.go
@@ -29,7 +29,7 @@ func ParseMode(rm string) Mode {
 	return Mode(rm)
 }
 
-func (m Mode) HasModeProxy() bool {
+func (m Mode) HasModeFile() bool {
 	return m == ModeDefault || m == ModeProxy
 }
 

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -105,7 +105,6 @@ func (c *Client) Token(ctx context.Context) (string, error) {
 
 // login authenticates to Vault using IAM auth, and sets the client's token.
 func (c *Client) login(ctx context.Context) error {
-
 	authConfig := config.AuthConfigFromEnv()
 	roleToAssumeArn := authConfig.AssumedRoleArn
 
@@ -114,16 +113,13 @@ func (c *Client) login(ctx context.Context) error {
 	/* If passing in a role (through VAULT_ASSUMED_ROLE_ARN enviornment variable)
 	to be assumed for Vault authentication, use it instead of the function execution role */
 	if roleToAssumeArn != "" {
-
 		c.logger.Debug(fmt.Sprintf("Trying to assume role with arn of %s to authenticate with Vault", roleToAssumeArn))
-
 		sessionName := "vault_auth"
 
 		result, err := c.stsSvc.AssumeRole(&sts.AssumeRoleInput{
 			RoleArn:         &roleToAssumeArn,
 			RoleSessionName: &sessionName,
 		})
-
 		if err != nil {
 			return fmt.Errorf("failed to assume role with arn of %s %w", roleToAssumeArn, err)
 		}
@@ -163,7 +159,7 @@ func (c *Client) login(ctx context.Context) error {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(req.HTTPRequest.Body)
+	body, err := io.ReadAll(req.HTTPRequest.Body)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -107,9 +107,6 @@ func (s *handler) handle() error {
 
 func (s *handler) runExtension(ctx context.Context, wg *sync.WaitGroup) (func(context.Context) error, error) {
 	s.logger.Info("Initialising")
-	defer func() {
-		s.logger.Info("Initialised")
-	}()
 
 	authConfig := config.AuthConfigFromEnv()
 	vaultConfig := api.DefaultConfig()
@@ -155,7 +152,7 @@ func (s *handler) runExtension(ctx context.Context, wg *sync.WaitGroup) (func(co
 
 	client.VaultClient = client.VaultClient.WithRequestCallbacks(api.RequireState(newState), vault.UserAgentRequestCallback(uaFunc)).WithResponseCallbacks()
 
-	if s.runMode.HasFileMode() {
+	if s.runMode.HasModeFile() {
 		if err := writePreconfiguredSecrets(client.VaultClient); err != nil {
 			return nil, err
 		}
@@ -165,7 +162,7 @@ func (s *handler) runExtension(ctx context.Context, wg *sync.WaitGroup) (func(co
 	client.VaultClient = client.VaultClient.WithRequestCallbacks().WithResponseCallbacks()
 
 	cleanupFunc := func(context.Context) error { return nil }
-	if s.runMode.HasModeFile() {
+	if s.runMode.HasModeProxy() {
 		ln, err := net.Listen("tcp", "127.0.0.1:8200")
 		if err != nil {
 			return nil, fmt.Errorf("failed to listen on port 8200: %w", err)
@@ -185,6 +182,7 @@ func (s *handler) runExtension(ctx context.Context, wg *sync.WaitGroup) (func(co
 		}
 	}
 
+	s.logger.Info("Initialised")
 	return cleanupFunc, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func (s *handler) runExtension(ctx context.Context, wg *sync.WaitGroup) (func(co
 	client.VaultClient = client.VaultClient.WithRequestCallbacks().WithResponseCallbacks()
 
 	cleanupFunc := func(context.Context) error { return nil }
-	if s.runMode.HasModeProxy() {
+	if s.runMode.HasModeFile() {
 		ln, err := net.Listen("tcp", "127.0.0.1:8200")
 		if err != nil {
 			return nil, fmt.Errorf("failed to listen on port 8200: %w", err)

--- a/quick-start/terraform/lambda.tf
+++ b/quick-start/terraform/lambda.tf
@@ -20,6 +20,7 @@ resource "aws_lambda_function" "function" {
       VAULT_SECRET_FILE_DB = "/tmp/vault_secret.json",
       VAULT_SECRET_PATH    = "secret/myapp/config",
       VAULT_ASSUMED_ROLE_ARN = var.assume_role ? aws_iam_role.extra_role[0].arn : "",
+      VAULT_RUN_MODE       = "default",
       DATABASE_URL         = aws_db_instance.main.address
     }
   }


### PR DESCRIPTION
## Background:

Currently, Vault Lambda Extension has two methodologies to get secrets, and both are enabled by default.
The two methods are called proxy and file mode. Proxy mode makes requests to the running Vault server, and file mode fetches secrets and writes them to disk.

## Summary

This PR adds the ability to control how secrets are fetched, either through proxy mode, file mode, or the default and existing behavior. This is controlled via an environment variable `VAULT_RUN_MODE`.
The default is `default`, which allows for fetching secret both via proxy and file simulataneously.

This also updates the quick-start example to make use of the `VAULT_RUN_MODE` flag.
* when set to `proxy`, it will run the proxy server and fetch secrets from there.
* when set to `file`, it will read the secrets from the `vault_secret.json` file.
* when set to `default`, it will read secrets from both the proxy server and the secret file.

The quick-start has been tested locally using `make quick-start`.
