### PR TITLE
update quick start example to use postgres version 14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+IMPROVEMENTS:
+* quick-start: Update Postgres version to 14.7
+
 ## 0.10.0 (March 30, 2023)
 
 IMPROVEMENTS:

--- a/quick-start/terraform/rds.tf
+++ b/quick-start/terraform/rds.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "main" {
   allocated_storage      = 20
   storage_type           = "gp2"
   engine                 = "postgres"
-  engine_version         = "12.9"
+  engine_version         = "14.7"
   instance_class         = var.db_instance_type
   db_name                = "lambdadb"
   username               = "vaultadmin"

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "instance_type" {
 
 # DB instance size
 variable "db_instance_type" {
-  default = "db.t2.micro"
+  default = "db.t3.micro"
 }
 
 # true if you want to set and use VAULT_ASSUME_ROLE_ARN


### PR DESCRIPTION
Updates the Postgres engine used in the quick-start example.