### PR TITLE
Exclude distributed tracing headers from cache key

### DIFF
--- a/internal/proxy/cache.go
+++ b/internal/proxy/cache.go
@@ -120,8 +120,8 @@ func computeRequestID(key *CacheKey) (string, error) {
 	cloned.Header.Del(VaultCacheControlHeaderName)
 	// remove standard distributed tracing headers (https://www.w3.org/TR/trace-context/),
 	// otherwise instrumented requests will always be unique
-	cloned.Header.Del("traceparent")
-	cloned.Header.Del("tracestate")
+	cloned.Header.Del("Traceparent")
+	cloned.Header.Del("Tracestate")
 	// Serialize the request
 	if err := cloned.Write(&b); err != nil {
 		return "", fmt.Errorf("failed to serialize request: %v", err)

--- a/internal/proxy/cache.go
+++ b/internal/proxy/cache.go
@@ -118,6 +118,10 @@ func computeRequestID(key *CacheKey) (string, error) {
 	cloned.Header.Del(api.HeaderForward)
 	cloned.Header.Del(api.HeaderInconsistent)
 	cloned.Header.Del(VaultCacheControlHeaderName)
+	// remove standard distributed tracing headers (https://www.w3.org/TR/trace-context/),
+	// otherwise instrumented requests will always be unique
+	cloned.Header.Del("traceparent")
+	cloned.Header.Del("tracestate")
 	// Serialize the request
 	if err := cloned.Write(&b); err != nil {
 		return "", fmt.Errorf("failed to serialize request: %v", err)

--- a/internal/proxy/cache_test.go
+++ b/internal/proxy/cache_test.go
@@ -61,6 +61,22 @@ func TestCache_computeRequestID(t *testing.T) {
 			false,
 		},
 		{
+			"ignore distributed tracing headers",
+			&CacheKey{
+				Request: &http.Request{
+					URL: &url.URL{
+						Path: "test",
+					},
+					Header: http.Header{
+						"Traceparent": []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+						"Tracestate":  []string{"rojo=00f067aa0ba902b7,congo=t61rcWkgMzE"},
+					},
+				},
+			},
+			"7b5db388f211fd9edca8c6c254831fb01ad4e6fe624dbb62711f256b5e803717",
+			false,
+		},
+		{
 			"nil CacheKey",
 			nil,
 			"",


### PR DESCRIPTION
- When using distributed tracing layers for New Relic or Open Telemetry, all outbound requests get decorated with standard trace context headers
- If using the vault extension alongside one of those distributed tracing layers, caching within the proxy won’t work as expected because, traceparent header, for example contains randomly generated IDs, rendering each request unique based on the existing cache key logic
- This PR changes the cache to ignore those standard tracing headers

fixes #146