### PR TITLE
SMRE-283 - Update crt prepare

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,7 +11,7 @@ project "vault-lambda-extension" {
   github {
     organization = "hashicorp"
     repository = "vault-lambda-extension"
-    release_branches = ["main", "test-crt-prepare"]
+    release_branches = ["main"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,7 +11,7 @@ project "vault-lambda-extension" {
   github {
     organization = "hashicorp"
     repository = "vault-lambda-extension"
-    release_branches = ["main"]
+    release_branches = ["main", "test-crt-prepare"]
   }
 }
 
@@ -29,53 +29,13 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["security-scan-binaries"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/SMRE-283

This PR onboards the repo to use the [prepare](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) workflow.

Moving all repos to use prepare will allow us to deprecate several CRT workflows.

Let us know in #team-selfmanaged-releng if you have any questions!

Successful prepare workflow run can be seen [here](https://github.com/hashicorp/crt-workflows-common/actions/runs/10810319184)