### PR TITLE
Update quick start demo with new AMI info

### DIFF
--- a/quick-start/terraform/aws.tf
+++ b/quick-start/terraform/aws.tf
@@ -17,7 +17,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["hc-base-ubuntu-*"]
   }
 
   filter {
@@ -25,6 +25,6 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["888995627335"] # Canonical
 }
 

--- a/quick-start/terraform/variables.tf
+++ b/quick-start/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "environment_name" {
 
 # URL for Vault OSS binary
 variable "vault_zip_file" {
-  default = "https://releases.hashicorp.com/vault/1.18.5/vault_1.18.5_linux_amd64.zip"
+  default = "https://releases.hashicorp.com/vault/1.19.5/vault_1.19.5_linux_amd64.zip"
 }
 
 # Instance size


### PR DESCRIPTION
The previous Ubuntu AMI being queried in the quick start demo has since been deleted. This PR updates the demo to use an existing registered AMI, and also updates the Vault version being used